### PR TITLE
Linking to Thingweb repo logo

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,9 +1,9 @@
 <h1>
   <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/eclipse-thingweb/thingweb/main/brand/logos/thingweb_for_dark_bg.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/eclipse-thingweb/thingweb/master/brand/logos/thingweb.svg">
-  <img title="Eclipse Thingweb" alt="Eclipse Thingweb logo" src="https://github.com/eclipse-thingweb/thingweb/raw/main/brand/logos/thingweb.svg" width="300">
-</picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/eclipse-thingweb/thingweb/main/brand/logos/thingweb_for_dark_bg.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/eclipse-thingweb/thingweb/master/brand/logos/thingweb.svg">
+    <img title="Eclipse Thingweb" alt="Eclipse Thingweb logo" src="https://github.com/eclipse-thingweb/thingweb/raw/main/brand/logos/thingweb.svg" width="300">
+  </picture>
 </h1>
 
 Eclipse Thingweb™ offers components for making IoT solutions interoperable at scale by leveraging the W3C WoT standards, no matter if improving an existing solution or building a new one:

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,8 +1,10 @@
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/eclipse-thingweb/website/master/misc/thingweb_logo_for_dark_bg.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/eclipse-thingweb/website/master/misc/thingweb_logo.svg">
-  <img title="ThingWeb" alt="Thingweb logo" src="" width="300px">
+<h1>
+  <picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/eclipse-thingweb/thingweb/main/brand/logos/thingweb_for_dark_bg.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/eclipse-thingweb/thingweb/master/brand/logos/thingweb.svg">
+  <img title="Eclipse Thingweb" alt="Eclipse Thingweb logo" src="https://github.com/eclipse-thingweb/thingweb/raw/main/brand/logos/thingweb.svg" width="300">
 </picture>
+</h1>
 
 Eclipse Thingweb™ offers components for making IoT solutions interoperable at scale by leveraging the W3C WoT standards, no matter if improving an existing solution or building a new one:
 


### PR DESCRIPTION
As mentioned in https://github.com/eclipse-thingweb/thingweb/issues/5 and agreed in last friday, this aligns the logo usage to thingweb repo.

This will change our github landing page at https://github.com/eclipse-thingweb